### PR TITLE
#17 編集画面レイアウト作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.8.1",
     "@eslint/eslintrc": "^1.2.1",
     "@material-ui/core": "^5.0.0-beta.5",
+    "@mui/icons-material": "^5.6.2",
     "@mui/material": "^5.6.4",
     "next": "12.1.5",
     "prettier": "^2.6.2",

--- a/pages/editTodo.tsx
+++ b/pages/editTodo.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+
+import {
+  Container,
+  FormLabel,
+  OutlinedInput,
+  Typography,
+  Box,
+  Stack,
+  styled,
+} from '@mui/material'
+import { Header } from '../components/Header'
+
+const EditTodo = () => {
+  // フォーム送信
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const data = new FormData(event.currentTarget)
+    console.log('title: ', data.get('title'))
+    console.log('detail: ', data.get('detail'))
+  }
+
+  return (
+    <>
+      <Header />
+      <Container component="div">
+        <Stack spacing={2} my={3}>
+          <Box
+            component="div"
+            sx={{ display: 'flex', justifyContent: 'space-between' }}
+          >
+            <Typography
+              component="h2"
+              fontSize="24px"
+              fontWeight={600}
+              alignSelf="center"
+            >
+              EDIT TODO
+            </Typography>
+            <SButton
+              sx={{
+                backgroundColor: '#9ae6b4',
+                color: '#000',
+                '&:hover': { backgroundColor: '#9ae6b4' },
+              }}
+            >
+              Back
+            </SButton>
+          </Box>
+          <form onSubmit={handleSubmit}>
+            <Stack spacing={3}>
+              <FormLabel sx={{ fontWeight: 600, fontSize: '20px' }}>
+                <div>TITLE</div>
+                <OutlinedInput
+                  id="title"
+                  name="title"
+                  fullWidth
+                  sx={{ fontWeight: 600, borderRadius: '10px' }}
+                />
+              </FormLabel>
+              <FormLabel sx={{ fontWeight: 600, fontSize: '20px' }}>
+                <div>DETAIL</div>
+                <OutlinedInput
+                  id="detail"
+                  name="detail"
+                  fullWidth
+                  multiline
+                  sx={{
+                    minHeight: '280px',
+                    alignItems: 'start',
+                    fontWeight: 600,
+                    borderRadius: '10px',
+                  }}
+                />
+              </FormLabel>
+              <Box
+                component="div"
+                sx={{ display: 'flex', justifyContent: 'space-between' }}
+              >
+                <Box display="flex">
+                  <Box mr={2}>
+                    <Typography>Create</Typography>
+                    <p style={{ margin: '0 0 0 10px', fontWeight: 600 }}>
+                      2022-5-8 18:55
+                    </p>
+                  </Box>
+                  <Box>
+                    <Typography>Update</Typography>
+                    <p style={{ margin: '0 0 0 10px', fontWeight: 600 }}>
+                      2022-5-9 20:00
+                    </p>
+                  </Box>
+                </Box>
+                <SButton
+                  type="submit"
+                  sx={{
+                    bgcolor: '#38a169',
+                    color: '#fff',
+                    '&:hover': { bgcolor: '#38a169' },
+                  }}
+                >
+                  UPDATE
+                </SButton>
+              </Box>
+            </Stack>
+          </form>
+        </Stack>
+      </Container>
+    </>
+  )
+}
+
+// Button 共通スタイル
+const SButton = styled('button')({
+  height: '40px',
+  width: '112px',
+  borderRadius: '100px',
+  border: '1px solid #000',
+  fontWeight: 600,
+  '&:hover': {
+    opacity: 0.7,
+  },
+})
+
+export default EditTodo

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,6 +288,13 @@
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
+"@mui/icons-material@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.6.2.tgz#239c40fc5841dc7c6af7d00e4e988550de170fcd"
+  integrity sha512-9QdI7axKuBAyaGz4mtdi7Uy1j73/thqFmEuxpJHxNC7O8ADEK1Da3t2veK2tgmsXsUlAHcAG63gg+GvWWeQNqQ==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+
 "@mui/material@^5.6.4":
   version "5.6.4"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.6.4.tgz#5c6d6770acaea84d7b1c6492639627baed62f65b"
@@ -857,7 +864,6 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-
 clone-regexp@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-2.2.0.tgz#7d65e00885cd8796405c35a737e7a86b7429e36f"
@@ -866,7 +872,6 @@ clone-regexp@^2.1.0:
     is-regexp "^2.0.0"
 
 clsx@^1.0.4, clsx@^1.1.1:
-
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==


### PR DESCRIPTION
## IssueのURL
closes #17

## 対応内容・対応背景・妥協点
Todoアプリ編集画面レイアウト作成

## やったこと
editTodo.tsxの追加

## やってないこと・できていないこと
特になし

## UI before / after
UIや振る舞いが変わる場合はbefore / afterのスクショや動画を共有する

<img width="1440" alt="スクリーンショット 2022-05-14 1 09 47" src="https://user-images.githubusercontent.com/18572630/168324067-2230d14a-f3d0-4b39-9f19-5ada6e2c5af1.png">

## テスト
コンソールにtitle, detailが出ることを確認

## レビュー観点
あくまで目安です。

- 想定通りに動作するか？
- より良いJS/JSX/TS/TSX/CSS/Reactの書き方はないか？
- より良い設計方法はないか？
- 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- 関数、コンポーネントの粒度は適切か？
- etc...

## 補足

※必要な項目だけ使用し、不要なものは削除すること
